### PR TITLE
75 redeploy service with new image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
     types: [opened, synchronize, closed]
     branches:
       - main
-  push:
-    branches:
-      - 75-redeploy-service-with-new-image
 
 env:
   IMAGE_NAME: spaced-repetition-web
@@ -16,7 +13,6 @@ env:
 
 jobs:
   lint:
-    if: false
     runs-on: ubuntu-22.04
     name: Lint
     steps:
@@ -32,7 +28,6 @@ jobs:
         run: npm run lint
       
   tests:
-    if: false
     needs:
       - lint
     runs-on: ubuntu-22.04
@@ -78,13 +73,13 @@ jobs:
           docker push $REPO/$IMAGE_NAME:${GITHUB_SHA::6}
   
   deploy:
-    # needs: 
-    #   - release
+    needs: 
+      - release
     runs-on: ubuntu-22.04
     name: Deploy
     steps:
       - name: Restart ECS Service
-        run: aws ecs describe-services --cluster sp --services sp-app
+        run: aws ecs update-service --cluster sp --services sp-app --force-new-deployment
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_SECRET_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,4 +84,8 @@ jobs:
     name: Deploy
     steps:
       - name: Restart ECS Service
-        run: aws --version
+        run: aws ecs describe-services --cluster sp --services sp-app
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_SECRET_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.REGION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
     name: Deploy
     steps:
       - name: Restart ECS Service
-        run: aws ecs update-service --cluster sp --services sp-app --force-new-deployment
+        run: aws ecs update-service --cluster sp --service sp-app --force-new-deployment
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_SECRET_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     types: [opened, synchronize, closed]
     branches:
       - main
+  push:
+    branches:
+      - 75-redeploy-service-with-new-image
 
 env:
   IMAGE_NAME: spaced-repetition-web
@@ -13,6 +16,7 @@ env:
 
 jobs:
   lint:
+    if: false
     runs-on: ubuntu-22.04
     name: Lint
     steps:
@@ -28,6 +32,7 @@ jobs:
         run: npm run lint
       
   tests:
+    if: false
     needs:
       - lint
     runs-on: ubuntu-22.04
@@ -71,3 +76,12 @@ jobs:
           docker push $REPO/$IMAGE_NAME
           docker tag $REPO/$IMAGE_NAME $REPO/$IMAGE_NAME:${GITHUB_SHA::6}
           docker push $REPO/$IMAGE_NAME:${GITHUB_SHA::6}
+  
+  deploy:
+    # needs: 
+    #   - release
+    runs-on: ubuntu-22.04
+    name: Deploy
+    steps:
+      - name: Restart ECS Service
+        run: aws --version


### PR DESCRIPTION
This MR has changes to the cicd flow such that when a new image is released, the aws service serving the app is redeployed with latest image.

Closes https://github.com/alieissa/spaced-repetition-web/issues/75