### PR TITLE
80 case of no decks not handled

### DIFF
--- a/src/modules/decks/DecksListPage.tsx
+++ b/src/modules/decks/DecksListPage.tsx
@@ -93,6 +93,9 @@ export default function Decks() {
       Untriggered: () => null,
       Loading: () => null,
       Success: () => {
+        if (_.isEmpty(decks)) {
+          return
+        }
         navigate(`${decks[0].id}`)
       },
       Failure: ({ value }) => {

--- a/src/modules/decks/__tests__/DecksListPage.test.tsx
+++ b/src/modules/decks/__tests__/DecksListPage.test.tsx
@@ -19,6 +19,7 @@ export const handlers = [
     return res(
       ctx.json([
         {
+          id: 'testDeck0id',
           name: 'Test Deck',
           card: [
             {
@@ -82,8 +83,8 @@ describe('DecksListPage', () => {
   })
 
   // TODO: Unstable test. Will address it in another ticket
-  describe.skip('interaction', () => {
-    it('should navigate to login on 401', async () => {
+  describe('interaction', () => {
+    it.skip('should navigate to login on 401', async () => {
       server.use(rest.get(decksUrl, (__, res, ctx) => res(ctx.status(401))))
 
       renderWithProviders(<DecksListPage />)
@@ -91,6 +92,25 @@ describe('DecksListPage', () => {
       await act(flushPromises)
 
       expect(mockNavigate).toHaveBeenCalledWith('/login')
+    })
+
+    it('should navigate to first deck when decks', async () => {
+      // Assemble
+      renderWithProviders(<DecksListPage />)
+      await act(flushPromises)
+
+      // Assert
+      expect(mockNavigate).toHaveBeenCalledWith('testDeck0id')
+    })
+
+    it('should NOT attempt to navigate to first deck when decks list is empty', async () => {
+      // Assemble
+      server.use(rest.get(decksUrl, (__, res, ctx) => res(ctx.json([]))))
+      renderWithProviders(<DecksListPage />)
+      await act(flushPromises)
+
+      // Assert
+      expect(mockNavigate).not.toHaveBeenCalledWith()
     })
   })
 })


### PR DESCRIPTION
This MR contains the fix of the navigation to non-existent deck bug. When a user has no decks we show the empty decks component.

Closes #80 